### PR TITLE
fix: make logo link to home on other pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,7 +1,18 @@
 ---
 import { Icon } from "astro-icon";
+
+const { pathname } = Astro.url;
+const isOnHomePage = pathname === "/" || pathname === "";
 ---
 
 <div class="container py-4 sm:py-8 relative">
-  <Icon name="logo-horizontal" class="w-60 sm:w-96" />
+  {
+    isOnHomePage ? (
+      <Icon name="logo-horizontal" class="w-60 sm:w-96" />
+    ) : (
+      <a href="/">
+        <Icon name="logo-horizontal" class="w-60 sm:w-96" />
+      </a>
+    )
+  }
 </div>


### PR DESCRIPTION
This conditionally wraps the Logo in an anchor element if it's not on
the home page.

Ref: https://docs.astro.build/en/tutorial/2-pages/3/#conditionally-render-elements

Fixes #18 
