### PR TITLE
feat: add support for utm_campaign

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -13,8 +13,8 @@ export function About() {
           </h4>
           <p>
             I studied abroad in Buenos Aires in 2013. Now I’m teaching my
-            daughter Argentinian Spanish 🇦🇷. I created this course because it’s
-            something <em>I wish existed</em> when I was first starting.{" "}
+            daughter Argentinian Spanish 🇦🇷. I created this newsletter to share
+            everything I learn with you.
           </p>
         </div>
       </div>

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -1,10 +1,11 @@
 ---
 import { SignupForm } from "./SignupForm";
 import { WaitlistSection } from "./WaitlistSection";
+const { source } = Astro.props;
 ---
 
 <div class="grid gap-4">
-  <SignupForm client:visible />
+  <SignupForm client:visible source={source} />
   <div class="flex items-center flex-wrap gap-4">
     <div class="flex items-center ml-4">
       <!-- Since Astro doesn't have dynamic imports, you'll have to manually specify the image URLs -->

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -10,7 +10,10 @@ type ResponseData = {
   totalCount: number;
 };
 
-export function SignupForm() {
+type SignupFormProps = {
+  source: string;
+};
+export function SignupForm({ source }: SignupFormProps) {
   const [state, setState] = useState<State>("initial");
   const [waitlistCount, setWaitlistCount] = useState(null);
   const [email, setEmail] = useState("");
@@ -45,7 +48,7 @@ export function SignupForm() {
       const res = await fetch("/signup.json", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, utmCampaign }),
+        body: JSON.stringify({ email, utmCampaign, source }),
       });
 
       const data = (await res.json()) as SignupResponseData;

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -27,6 +27,9 @@ export function SignupForm() {
 
     let ignore = false;
     fetchWaitlistTotal();
+    const searchParams = new URLSearchParams(document.location.search);
+    console.log(searchParams.get("utm_campaign"));
+
     return () => {
       ignore = true;
     };
@@ -37,10 +40,12 @@ export function SignupForm() {
     event.preventDefault();
 
     try {
+      const searchParams = new URLSearchParams(document.location.search);
+      const utmCampaign = searchParams.get("utm_campaign") || "none";
       const res = await fetch("/signup.json", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, utmCampaign }),
       });
 
       const data = (await res.json()) as SignupResponseData;

--- a/src/components/ThankYou.tsx
+++ b/src/components/ThankYou.tsx
@@ -29,7 +29,7 @@ export function ThankYou() {
         Thank you!
       </h1>
       <img
-        className="mx-auto mb-4 sm:mb-8 max-w-full h-auto"
+        className="mx-auto mb-4 sm:mb-8 max-w-full h-auto sm:max-w-xs"
         src="https://media.giphy.com/media/W1TPavKSPEVVjz4LAJ/giphy.gif"
       />
       <p className="text-sm sm:text-lg mb-4 sm:mb-8 text-center px-4">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,6 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = 'Speak Argentinian Spanish';
-export const SITE_DESCRIPTION = 'The best course for learning Argentinian Spanish.';
+export const SITE_TITLE = "Speak Argentinian Spanish";
+export const SITE_DESCRIPTION =
+  "The best newsletter for learning Argentinian Spanish.";

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,7 +17,7 @@ import Heading from "../components/ui/Heading.astro";
     <div class="bg-arg-dark p-6 sm:p-8">
       <div class="mx-auto grid gap-6 place-content-center">
         <Heading tag={"h2"} size={"h3"}>Get on the waitlist</Heading>
-        <CTA />
+        <CTA source="404-page" />
       </div>
     </div>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,10 +18,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                 >
               </Heading>
               <p class="max-w-lg">
-                Every Monday morning, I send a 5-minute newsletter to help your Spanish sound more Argentinian.
+                Every Monday morning, I send a 5-minute newsletter to help your
+                Spanish sound more Argentinian.
               </p>
             </div>
-            <CTA />
+            <CTA source="index-page" />
           </div>
         </div>
       </div>

--- a/src/pages/signup.json.ts
+++ b/src/pages/signup.json.ts
@@ -8,7 +8,7 @@ export async function post({ request, redirect }) {
     utm_campaign?: string;
   } = {
     email: body.email,
-    utm_source: "website",
+    utm_source: body.source ? `website-${body.source}` : "website",
     referring_site: "speakargentinianspanish.com",
   };
 

--- a/src/pages/signup.json.ts
+++ b/src/pages/signup.json.ts
@@ -1,14 +1,23 @@
 export async function post({ request, redirect }) {
   const body = await request.json();
 
-  const postBody = {
+  const postBody: {
+    email: string;
+    utm_source: string;
+    referring_site: string;
+    utm_campaign?: string;
+  } = {
     email: body.email,
     utm_source: "website",
     referring_site: "speakargentinianspanish.com",
-    // TODO@jsjoeio - refactor CTA to allow us to pass in
-    // then make these required
-    // utm_campaign: blog_post_footer, etc. (we could get more specific too)
   };
+
+  // On the frontend, we pass "none" if utm_campaign query param
+  // not found in the URL. See <SignupForm.tsx />
+  if (body.utmCampaign && body.utmCampaign !== "none") {
+    postBody.utm_campaign = body.utmCampaign;
+  }
+
   const url =
     "https://api.beehiiv.com/v2/publications/pub_6fcf5bfc-5793-49e6-b6b2-abcf322a6fd7/subscriptions";
   const options = {


### PR DESCRIPTION
## Description

### Adds `utm_campaign` support via query param

This will add the utm_campaign to the API request if it's found in the
URL. Tested locally using `https://3000--dev--egghead--jsjoeio--apps.dev.coder.com/?utm_campaign=instagram-bio`

![image](https://user-images.githubusercontent.com/3806031/236697735-08239fe2-b1ac-44d5-a678-c805495223cd.png)

### Adds `source` support via component props

This allows you to pass a string to `<CTA />` to label the source for the CTA i.e. `404-page` or `index-page`.

![image](https://user-images.githubusercontent.com/3806031/236697955-5622c8cf-bdd5-44c8-9efd-51521a74b641.png)

Fixes #33 
